### PR TITLE
docs: Point README to the examples-dotnet repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **These examples have moved.** The client-side .NET SDK examples now live in the [examples-dotnet repository](https://github.com/launchdarkly/examples-dotnet). This repository remains to support legacy references.
+
 # LaunchDarkly sample .NET client-side application
 
 We've built simple demo applications that demonstrate how the LaunchDarkly client-side .NET SDK works. There are two demos:


### PR DESCRIPTION
## Summary

Prepends a GitHub `[!IMPORTANT]` notice to the README pointing users to **[launchdarkly/examples-dotnet](https://github.com/launchdarkly/examples-dotnet)**, where the client-side .NET examples now live. The original README is kept intact below the notice.

**Merge order:** merge **before** the Terraform PR that archives this repo (launchdarkly/terraform#26022) — an archived repo is read-only.

Part of SDK-2561.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or security impact.
> 
> **Overview**
> Adds a GitHub **`[!IMPORTANT]`** callout at the top of **README.md** so visitors see that client-side .NET SDK examples moved to **[launchdarkly/examples-dotnet](https://github.com/launchdarkly/examples-dotnet)**. The callout states this repo stays available for legacy links; the rest of the README (console and MAUI build instructions) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418d8569ac90bbb4e4b34bb1f15b57114ce94fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->